### PR TITLE
Clarify setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,21 @@ A plugin to insert appropriate `flame::start_guard(_)` calls (for use with [flam
 
 Usage:
 
-In your Cargo.toml add `flame = "*"` to your `[dependencies]` (You may also opt for an optional dependency). Then in your crate root, add the following:
+In your Cargo.toml add `flame` and `flamer` to your dependencies:
+
+```toml
+[dependencies]
+flame = "*"
+flamer = "*"
+```
+
+You may also opt for an optional dependency. Then in your crate root, add the following:
 
 ```
 #![feature(plugin)]
 #![plugin(flamer)]
+
+extern crate flame;
 ```
 
 You should then be able to annotate every item (or even the whole crate) with `#[flame]` annotations. Note that this only instruments the annotated methods, it does not print out the results.


### PR DESCRIPTION
I wanted to use flamer with a project that wasn't yet using flame, so I needed to add flame and flamer, and extern crate flame to get my project to compile with a flame annotation.