### PR TITLE
Bugfixing

### DIFF
--- a/tests/double.rs
+++ b/tests/double.rs
@@ -26,6 +26,11 @@ fn main() {
     let frames = flame::frames();
     assert_eq!(1, frames.len());
     let roots = &frames[0].roots;
-    // if more than 3 roots, a() was flamed twice or c was flamed
-    assert_eq!(3, roots.len()); // 1 for main, a and b each
+    println!("{:?}",roots);
+    // if more than 2 roots, a() was flamed twice or c was flamed
+    // main is missing because main isn't closed here
+    assert_eq!(1, roots.len());
+    assert_eq!("b", roots[0].name);
+    assert_eq!(1, roots[0].children.len());
+    assert_eq!("a", roots[0].children[0].name);
 }

--- a/tests/flamed.rs
+++ b/tests/flamed.rs
@@ -35,5 +35,5 @@ fn test_flame() {
     let frames = flame::frames();
     assert_eq!(1, frames.len());
     let roots = &frames[0].roots;
-    assert_eq!(95, roots.len());
+    assert_eq!(1, roots.len());
 }


### PR DESCRIPTION
* it seems like the guard is been optimized out in some cases, so call
explicitly end on it after the block finished
* If using #![flame] the plugin will crash if there is some macro
definition/usage on function/module level. So prevent it from inspecting
macros further