### PR TITLE
Update for flame 0.1.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flamer"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Andre Bogus <bogusandre@gmail.com>"]
 description = "a procedural macro to insert `flame::start_guard(_)` calls"
 license = "Apache-2.0"
@@ -12,4 +12,4 @@ keywords = ["flame-graph", "profiling", "compiler-plugin"]
 plugin = true
 
 [dependencies]
-flame = "^0.1.2"
+flame = "^0.1.9"

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ In your Cargo.toml add `flame` and `flamer` to your dependencies:
 
 ```toml
 [dependencies]
-flame = "^0.1.2"
-flamer = "^0.1.2"
+flame = "^0.1.9"
+flamer = "^0.1.3"
 ```
 
 Then in your crate root, add the following:
@@ -31,8 +31,8 @@ You may also opt for an *optional dependency*. In that case your Cargo.toml shou
 
 ```toml
 [dependencies]
-flame = { version = "^0.1.2", optional = true }
-flamer = { version = "^0.1.2", optional = true }
+flame = { version = "^0.1.9", optional = true }
+flamer = { version = "^0.1.3", optional = true }
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use syntax::codemap::{DUMMY_SP, Span};
 use syntax::ext::base::{Annotatable, ExtCtxt, SyntaxExtension};
 use syntax::ext::build::AstBuilder;
 use syntax::feature_gate::AttributeType;
-use syntax::parse::token;
+use syntax::symbol::Symbol;
 use syntax::util::small_vector::SmallVector;
 
 pub fn insert_flame_guard(cx: &mut ExtCtxt, _span: Span, _mi: &MetaItem,
@@ -90,7 +90,7 @@ impl<'a, 'cx> Folder for Flamer<'a, 'cx> {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_syntax_extension(token::intern("flame"),
+    reg.register_syntax_extension(Symbol::intern("flame"),
         SyntaxExtension::MultiModifier(Box::new(insert_flame_guard)));
     reg.register_attribute(String::from("noflame"), AttributeType::Whitelisted);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,11 @@ impl<'a, 'cx> Folder for Flamer<'a, 'cx> {
 
     fn fold_item_simple(&mut self, i: Item) -> Item {
         fn is_flame_annotation(attr: &Attribute) -> bool {
-            if let MetaItemKind::Word(ref name) = attr.value.node {
-                name == "flame" || name == "noflame"
-            } else {
-                false
+            match attr.value.node {
+                MetaItemKind::Word => {
+                    attr.value.name.as_str() == "flame"
+                },
+                _ => false
             }
         }
         // don't double-flame nested annotations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,8 @@ impl<'a, 'cx> Folder for Flamer<'a, 'cx> {
         fn is_flame_annotation(attr: &Attribute) -> bool {
             match attr.value.node {
                 MetaItemKind::Word => {
-                    attr.value.name.as_str() == "flame"
+                    let name = &*attr.value.name.as_str();
+                    name == "flame" || name == "noflame"
                 },
                 _ => false
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ impl<'a, 'cx> Folder for Flamer<'a, 'cx> {
 
     fn fold_block(&mut self, block: P<Block>) -> P<Block> {
         block.map(|block| {
-            let name = self.cx.expr_str(DUMMY_SP, self.ident.name.as_str());
+            let name = self.cx.expr_str(DUMMY_SP, self.ident.name);
             quote_block!(self.cx, {
                 let g = ::flame::start_guard($name);
                 let r = $block;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ impl<'a, 'cx> Folder for Flamer<'a, 'cx> {
 
     fn fold_item_simple(&mut self, i: Item) -> Item {
         fn is_flame_annotation(attr: &Attribute) -> bool {
-            if let MetaItemKind::Word(ref name) = attr.node.value.node {
+            if let MetaItemKind::Word(ref name) = attr.value.node {
                 name == "flame" || name == "noflame"
             } else {
                 false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ impl<'a, 'cx> Folder for Flamer<'a, 'cx> {
         if i.attrs.iter().any(is_flame_annotation) { return i; }
         if let ItemKind::Mac(_) = i.node {
             return i;
-        }else {
+        } else {
             self.ident = i.ident; // update in case of nested items
             fold::noop_fold_item_simple(i, self)
         }

--- a/tests/double.rs
+++ b/tests/double.rs
@@ -23,14 +23,13 @@ fn c() {
 #[test]
 fn main() {
     c();
-    let frames = flame::spans();
-    assert_eq!(1, frames.len());
-    let roots = &frames[0].roots;
+    let spans = flame::spans();
+    assert_eq!(1, spans.len());
+    let roots = &spans[0];
     println!("{:?}",roots);
     // if more than 2 roots, a() was flamed twice or c was flamed
     // main is missing because main isn't closed here
-    assert_eq!(1, roots.len());
-    assert_eq!("b", roots[0].name);
-    assert_eq!(1, roots[0].children.len());
-    assert_eq!("a", roots[0].children[0].name);
+    assert_eq!("b", roots.name);
+    assert_eq!(1, roots.children.len());
+    assert_eq!("a", roots.children[0].name);
 }

--- a/tests/flamed.rs
+++ b/tests/flamed.rs
@@ -32,8 +32,8 @@ fn a() -> u32 {
 #[test]
 fn test_flame() {
     assert_eq!(459, a());
-    let frames = flame::frames();
-    assert_eq!(1, frames.len());
-    let roots = &frames[0].roots;
-    assert_eq!(1, roots.len());
+    let spans = flame::spans();
+    assert_eq!(1, spans.len());
+    let roots = &spans[0];
+    assert_eq!(3, roots.children.len());
 }


### PR DESCRIPTION
New to rust. I got the tool up and running with the latest changes to rust nightly as well as flame 0.1.9. I was able to confirm functionality with #[flame] for individual functions but was unable to see it working for whole crates as mentioned in the read me. There may be something still missing. If so please advise and I'll attempt to correct. I figure this is better than nothing.