### PR TITLE
Fixed small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ And your crate root should contain:
 #![cfg_attr(feature="flame_it", feature(plugin, custom_attribute))]
 #![cfg_attr(feature="flame_it", plugin(flamer))]
 
-#[cfg(feature="flame_it")
+#[cfg(feature="flame_it")]
 extern crate flame;
 
 // as well as the following instead of `#[flame]`


### PR DESCRIPTION
There was one `]` missing.

Thanks for this awesome library.