### PR TITLE
Don't flame constant functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "flamer"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "flame 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,10 @@ extern crate syntax;
 
 use rustc_plugin::registry::Registry;
 use syntax::ast::{Attribute, Block, Expr, ExprKind, Ident, Item, ItemKind, Mac,
-                  MetaItem};
+                  MetaItem, Constness};
 use syntax::fold::{self, Folder};
 use syntax::ptr::P;
-use syntax::codemap::{DUMMY_SP, Span};
+use syntax::codemap::{DUMMY_SP, Span, Spanned};
 use syntax::ext::base::{Annotatable, ExtCtxt, SyntaxExtension};
 use syntax::ext::build::AstBuilder;
 use syntax::feature_gate::AttributeType;
@@ -51,6 +51,12 @@ impl<'a, 'cx> Folder for Flamer<'a, 'cx> {
         }
         // don't double-flame nested annotations
         if i.attrs.iter().any(is_flame_annotation) { return i; }
+
+        // don't flame constant functions
+        if let ItemKind::Fn(_, _, Spanned{ node: Constness::Const, .. }, ..) = i.node {
+            return i;
+        }
+
         if let ItemKind::Mac(_) = i.node {
             return i;
         } else {

--- a/tests/flamed_const.rs
+++ b/tests/flamed_const.rs
@@ -1,0 +1,39 @@
+#![feature(plugin, custom_attribute, const_fn)]
+#![plugin(flamer)]
+#![flame]
+
+extern crate flame;
+
+const fn e() -> u32 {
+    2
+}
+
+fn d() -> u32 {
+    e() << e()
+}
+
+fn c() -> u32 {
+    d() * d() * d() - 1
+}
+
+fn b() -> u32 {
+    (0..3).map(|_| c()).fold(0, |x, y| x + y)
+}
+
+fn a() -> u32 {
+    let mut result = 0;
+    for _ in 0..3 {
+        result += b()
+    }
+    result / 10
+}
+
+
+#[test]
+fn test_flame() {
+    assert_eq!(459, a());
+    let spans = flame::spans();
+    assert_eq!(1, spans.len());
+    let roots = &spans[0];
+    assert_eq!(3, roots.children.len());
+}


### PR DESCRIPTION
Currently `#[flame]` results in an error on constant functions, about not being able to call non constant functions. This resolves it by simply not modifying constant functions, which allows me to `#![flame]` my entire crate, or modules including constant functions.

It would be nice to at least give some sort of warning on `#[flame]` directly applied to a constant function - I don't know enough about the compiler internals for that to be an easy fix for me to make though.

Also updated `Cargo.lock` to say version 0.2.0, since running `cargo test` does that.