### PR TITLE
Improved sample snippet from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Then in your crate root, add the following:
 #![plugin(flamer)]
 
 extern crate flame;
+
+#[flame]
+// The item to apply `flame` to goes here.
 ```
 
 You may also opt for an *optional dependency*. In that case your Cargo.toml should have:
@@ -50,7 +53,8 @@ And your crate root should contain:
 extern crate flame;
 
 // as well as the following instead of `#[flame]`
-#[cfg_attr(feature="flame_it", flame)];
+#[cfg_attr(feature="flame_it", flame)]
+// The item to apply `flame` to goes here.
 ```
 
 You should then be able to annotate every item (or even the whole crate) with


### PR DESCRIPTION
The snippet has a wrong trailing semicolon which leads to a compiler error:

```
25 |     #[cfg_attr(feature="flame_it", flame)];
   |                                           ^ expected one of 8 possible tokens here
```

We might also want to make clearer that `#[flame]` has to be attached to an item, not just types somewhere.