### PR TITLE
Add optional prefix for annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "flamer"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "flame 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `flame` annotation can also take an optional parameter specifying a string
 to prefix to enclosed method names. This is especially useful when annotating
 multiple methods with the same name, but in different modules.
 
-```
+```rust
 #[flame("prefix")]
 fn method_name() {
     //The corresponding block on the flamegraph will be named "prefix::method_name"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ You should then be able to annotate every item (or even the whole crate) with
 instrumentations for subitems of `#[flame]`d items. Note that this only
 instruments the annotated methods, it does not print out the results.
 
+The `flame` annotation can also take an optional parameter specifying a string
+to prefix to enclosed method names. This is especially useful when annotating
+multiple methods with the same name, but in different modules.
+
+```
+#[flame("prefix")]
+fn method_name() {
+    //The corresponding block on the flamegraph will be named "prefix::method_name"
+}
+```
+
 Refer to [flame's documentation](https://docs.rs/flame) to see how output works.
 
 License: Apache 2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,20 +22,16 @@ pub fn insert_flame_guard(cx: &mut ExtCtxt, _span: Span, mi: &MetaItem,
                           a: Annotatable) -> Annotatable {
     let opt_ident = match mi.node {
         MetaItemKind::Word => None,
-        MetaItemKind::List(ref v) => {
-            if v.len() != 1 {
-                None
-            } else {
-                match v.get(0).unwrap().literal() {
-                    None => None,
-                    Some(l) => match l.node {
-                        LitKind::Str(s, _style) => Some(s),
-                        _ => None,
-                    }
+        MetaItemKind::List(ref v) if v.len() == 1 => {
+            match v.get(0).unwrap().literal() {
+                None => None,
+                Some(l) => match l.node {
+                    LitKind::Str(s, _style) => Some(s),
+                    _ => None,
                 }
             }
         },
-        MetaItemKind::NameValue(_) => None,
+        _ => None,
     };
     match a {
         Annotatable::Item(i) => Annotatable::Item(

--- a/tests/opt_name.rs
+++ b/tests/opt_name.rs
@@ -21,9 +21,7 @@ fn c() {
     b()
 }
 
-pub struct Lower {
-    
-}
+pub struct Lower;
 
 impl Lower {
     #[flame("lower")]

--- a/tests/opt_name.rs
+++ b/tests/opt_name.rs
@@ -1,0 +1,35 @@
+// test double attrs
+
+#![feature(plugin, custom_attribute)]
+#![plugin(flamer)]
+#![flame("e")]
+
+extern crate flame;
+
+#[flame]
+fn a() {
+    // nothing to do here
+}
+
+fn b() {
+    a()
+}
+
+#[noflame]
+fn c() {
+    b()
+}
+
+#[test]
+fn main() {
+    c();
+    let spans = flame::spans();
+    assert_eq!(1, spans.len());
+    let roots = &spans[0];
+    println!("{:?}",roots);
+    // if more than 2 roots, a() was flamed twice or c was flamed
+    // main is missing because main isn't closed here
+    assert_eq!("e::b", roots.name);
+    assert_eq!(1, roots.children.len());
+    assert_eq!("a", roots.children[0].name);
+}

--- a/tests/opt_name.rs
+++ b/tests/opt_name.rs
@@ -1,16 +1,17 @@
-// test double attrs
+// test optional prefix
 
 #![feature(plugin, custom_attribute)]
 #![plugin(flamer)]
-#![flame("e")]
 
 extern crate flame;
 
-#[flame]
+#[flame("top")]
 fn a() {
-    // nothing to do here
+    let l = Lower {};
+    l.a();
 }
 
+#[flame]
 fn b() {
     a()
 }
@@ -18,6 +19,17 @@ fn b() {
 #[noflame]
 fn c() {
     b()
+}
+
+pub struct Lower {
+    
+}
+
+impl Lower {
+    #[flame("lower")]
+    pub fn a(self) {
+        // nothing to do here
+    }
 }
 
 #[test]
@@ -29,7 +41,9 @@ fn main() {
     println!("{:?}",roots);
     // if more than 2 roots, a() was flamed twice or c was flamed
     // main is missing because main isn't closed here
-    assert_eq!("e::b", roots.name);
+    assert_eq!("b", roots.name);
     assert_eq!(1, roots.children.len());
-    assert_eq!("a", roots.children[0].name);
+    assert_eq!("top::a", roots.children[0].name);
+    assert_eq!(1, roots.children[0].children.len());
+    assert_eq!("lower::a", roots.children[0].children[0].name);
 }


### PR DESCRIPTION
There were a few people interested in issue #16. I just stumbled upon this crate -- I love the idea behind it, but I also need that feature to use it in my own work since I have a few different structs with methods of the same name.

I think having automatic full path names would be even nicer than this solution, but I'm not that well versed with writing language extensions just yet. In the meantime, this works well enough for my (and hopefully others') needs.