### PR TITLE
Document support for stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,9 @@ proc_macro = true
 flame = "0.2.2"
 syn = { version = "0.15.18", features = ["extra-traits", "full", "fold", "parsing"] }
 quote = "0.6.9"
+
+[features]
+# WARNING: This Cargo feature is not intended for public usage!
+# Used to test `flamer` for module support which currently requires nightly
+# Rust.
+test-nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,21 @@
 //! A procedural attribute-macro to insert `flame` calls into code
 //!
-//! You can annotate modules or functions with `#[flame]` (currently you cannot
-//! annotate the whole crate, alas). You can also annotate modules, functions
-//! or other items with `#[noflame]` to omit them from the flame tracing.
+//! The feature parity varies between versions of Rust:
+//! * On stable and beta, you can annotate functions with `#[flame]`.
+//! * On nightly, you can also annotate modules with `#[flame]`.
+//!   You will need to add `#![feature(proc_macro_hygiene)]` in the crate root
+//!   ([related issue][proc_macro_hygiene tracking issue]).
+//!
+//! Alas, currently you cannot annotate the whole crate. For details about why,
+//! see the [custom inner attributes] issue.
+//!
+//! You can also annotate modules, functions or other items with `#[noflame]` to
+//! omit them from the flame tracing.
+//! For any given Rust version, the list of supported items for `#[noflame]` is
+//! the same as for `#[flame]`.
+//!
+//! [proc_macro_hygiene tracking issue]: https://github.com/rust-lang/rust/issues/54727
+//! [custom inner attributes]: https://github.com/rust-lang/rust/issues/54726
 
 extern crate syn;
 extern crate quote;

--- a/tests/double.rs
+++ b/tests/double.rs
@@ -1,8 +1,10 @@
-#![feature(custom_attribute, proc_macro_hygiene)]
-// test double attrs
+//! Test double attrs.
 
-#[macro_use] extern crate flamer;
+#![cfg(feature = "test-nightly")]
+#![feature(proc_macro_hygiene)]
+
 extern crate flame;
+#[macro_use] extern crate flamer;
 
 #[flame]
 mod inner {

--- a/tests/flamed.rs
+++ b/tests/flamed.rs
@@ -1,8 +1,10 @@
-#![feature(custom_inner_attributes, proc_macro_hygiene)]
+//! Test basic `flamer` usage.
 
-#[macro_use] extern crate flamer;
+#![cfg(feature = "test-nightly")]
+#![feature(proc_macro_hygiene)]
 
 extern crate flame;
+#[macro_use] extern crate flamer;
 
 #[flame]
 mod inner {

--- a/tests/flamed_const.rs
+++ b/tests/flamed_const.rs
@@ -1,9 +1,12 @@
+//! Test `flamer` usage with const functions and methods.
+
+#![cfg(feature = "test-nightly")]
 #![feature(proc_macro_hygiene)]
 
-extern crate flamer;
-use flamer::flame;
-
 extern crate flame;
+extern crate flamer;
+
+use flamer::flame;
 
 #[flame]
 mod inner {

--- a/tests/opt_name.rs
+++ b/tests/opt_name.rs
@@ -1,9 +1,9 @@
-// test optional prefix
-
-extern crate flamer;
-use flamer::{flame, noflame};
+//! Test optional prefix.
 
 extern crate flame;
+extern crate flamer;
+
+use flamer::{flame, noflame};
 
 #[flame("top")]
 fn a() {


### PR DESCRIPTION
Turns out, `flamer` can be compiled with stable Rust, just without support for modules.